### PR TITLE
feat: 카카오 로그인 서버 연동

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.example.hankkitoktok.hankkitoktok">
+    package="com.example.hankkitoktok">
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
     <uses-permission android:name="android.permission.VIBRATE" />
@@ -10,7 +10,7 @@
 
     <application
         android:label="hankkitoktok"
-        android:name="hankkitoktok"
+        android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
 
         <activity

--- a/lib/const/strings.dart
+++ b/lib/const/strings.dart
@@ -1,2 +1,3 @@
 String YOUR_NATIVE_APP_KEY = 'YOUR_NATIVE_APP_KEY';
 String YOUR_JAVASCRIPT_APP_KEY = 'YOUR_JAVA_SCRIPT_APP_KEY';
+String BASE_URL = 'http://mealtoktok.p-e.kr';

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:hankkitoktok/screen/0_login_and_set_address/0_login_screen.dart';
 import 'package:hankkitoktok/const/color.dart';
+import 'package:hankkitoktok/screen/0_login_and_set_address/temporary_adress.dart';
 import 'package:hankkitoktok/screen/2_home/0_home.dart';
 import 'package:hankkitoktok/screen/2_home/1_home_screen.dart';
 import 'package:hankkitoktok/screen/3_menu_choice/0_set_meal_name_screen.dart';
@@ -154,7 +155,7 @@ class MyApp extends StatelessWidget {
         //   page: () => CommunityScreen(),
         // ),
       ],
-      home: LoginPage(),
+      home: TemporaryAddress(),
     );
   }
 }

--- a/lib/models/user/user_data.dart
+++ b/lib/models/user/user_data.dart
@@ -1,0 +1,201 @@
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import 'package:hankkitoktok/const/strings.dart';
+import 'package:http/http.dart' as http;
+import 'package:shared_preferences/shared_preferences.dart';
+
+//회원가입
+Future<void> signUp(String address, double latitude, double longitude,
+    String accessToken, String idToken, String deviceToken) async {
+  try {
+    Uri uri = Uri.parse('$BASE_URL/api/v1/auth/oauth/sign-up');
+    var data = jsonEncode({
+      "oAuthTokens": {
+        'accessToken': accessToken,
+        'idToken': idToken,
+      },
+      'deviceToken': deviceToken,
+      'addressInfo': {
+        'address': address,
+        'latitude': latitude,
+        'longitude': longitude,
+      },
+    });
+
+    http.Response response = await http.post(
+      uri,
+      headers: {'Content-Type': 'application/json'},
+      body: data,
+    );
+    if (response.statusCode == 200) {
+      SharedPreferences prefs = await SharedPreferences.getInstance();
+      var responseBody = jsonDecode(utf8.decode(response.bodyBytes));
+
+      //prefs.setString("access_token", responseBody['token']['access']);
+      //prefs.setString("refresh_token", responseBody['token']['refresh']);
+
+      debugPrint(responseBody.toString());
+
+      //회원가입 성공하면 로그인 진행
+      await login(accessToken, idToken, deviceToken);
+
+    } else {
+      // 에러 처리
+      debugPrint('인증 실패: ${response.body}');
+      debugPrint('Error: ${response.statusCode}');
+    }
+  } catch (e) {
+    // 네트워크 요청 실패 시 처리
+    debugPrint('네트워크 요청 실패: $e');
+  }
+}
+
+// Future<bool> getIsUser(String idToken) async {
+//   SharedPreferences prefs = await SharedPreferences.getInstance(); // 저장소
+//
+//   String accessToken = prefs.getString('access_token') ?? '';
+//   Uri uri = Uri.parse('$BASE_URL/api/v1/auth/oauth/can-sign-up');
+//   http.Response response;
+//   Map<String, String> header = {
+//     'Content-Type': 'application/json',
+//     'idToken': '$idToken',
+//   };
+//   response = await http.get(uri, headers: header);
+//
+//   if (response.statusCode == 401) {
+//     // access token이 만료되었을 경우,
+//     await tokenRefresh(prefs); // refresh token으로 token을 refresh한 후 다시 요청
+//     bool serviceUser = await getIsUser(idToken);
+//     debugPrint('401111111111111');
+//
+//     return serviceUser;
+//   } else if (response.statusCode == 400) {
+//     // access token이 invalid할 경우
+//     debugPrint(response.body);
+//     debugPrint('400000000000');
+//   }
+//   //401: 토큰 만료, 400: 인증 에러, 200: 성공, else: 나머지 에러
+//   if (response.statusCode == 200) {
+//     var responseBody = jsonDecode(utf8.decode(response.bodyBytes));
+//     return responseBody.result;
+//   } else {
+//     debugPrint(response.statusCode.toString());
+//     debugPrint('2222222222200');
+//     return false;
+//   }
+// }
+
+//등록된 유저인지 확인
+Future<bool> getIsUser(String idToken) async {
+  SharedPreferences prefs = await SharedPreferences.getInstance(); // 저장소
+  String accessToken = prefs.getString('access_token') ?? '';
+
+  Uri uri =
+      Uri.parse('$BASE_URL/api/v1/auth/oauth/can-sign-up?idToken=$idToken');
+
+  try {
+    final response =
+        await http.get(uri, headers: {'Content-Type': 'application/json'});
+
+    if (response.statusCode == 401) {
+      // access token이 만료되었을 경우,
+      // await tokenRefresh(prefs); // refresh token으로 token을 refresh한 후 다시 요청
+      // bool serviceUser = await getIsUser(idToken);
+      debugPrint('Error: 401');
+
+      return false;
+    } else if (response.statusCode == 400) {
+      // access token이 invalid할 경우
+      debugPrint(response.body);
+      debugPrint('Error: 400');
+      return false;
+
+    }
+    //401: 토큰 만료, 400: 인증 에러, 200: 성공, else: 나머지 에러
+    else if (response.statusCode == 200) {
+      var responseBody = jsonDecode(utf8.decode(response.bodyBytes));
+      debugPrint('200');
+      return true;
+    } else {
+      debugPrint('Error: ${response.statusCode}');
+      return false;
+    }
+  } catch (e) {
+      debugPrint('Request failed: $e');
+      return false;
+  }
+}
+
+
+// Future<void> tokenRefresh(SharedPreferences prefs) async {
+//   Uri uri = Uri.parse('$BASE_URL/api/token/refresh/');
+//   String refreshToken = prefs.getString('refresh_token') ?? '';
+//   // {
+//   //   "refresh": "enskagharktjaslkyhrselkygjdslkures;atawekjrhlsrj;egahejorv"
+//   // }
+//   var data = jsonEncode({
+//     'refresh': refreshToken,
+//   });
+//
+//   http.Response refreshResponse = await http.post(uri, headers: {
+//     'Content-Type': 'application/json',
+//   });
+//   var responseBody = jsonDecode(refreshResponse.body);
+//   await prefs.setString("access_token", responseBody['token']['access']);
+//   await prefs.setString("refresh_token", responseBody['token']['refresh']);
+// }
+
+
+//로그인
+Future<void> login(String accessToken, String idToken, String deviceToken) async {
+  Uri authUri = Uri.parse('$BASE_URL/api/v1/auth/oauth/login'); // HTTPS 사용 권장
+  var queryParams = {
+    'oAuthTokens': jsonEncode({
+      'accessToken': accessToken,
+      'idToken': idToken,
+    }),
+    'device-token': deviceToken,
+  };
+
+  try {
+    http.Response authResponse = await http.post(
+      authUri.replace(queryParameters: queryParams),
+      headers: {'Content-Type': 'application/json'},
+    );
+
+    if (authResponse.statusCode == 200) {
+      //SharedPreferences prefs = await SharedPreferences.getInstance();
+      var responseBody = jsonDecode(authResponse.body);
+      debugPrint('성공');
+      // json web token를 활용하여 access_token, refresh_token을 로컬 스토리지에 저장
+      //prefs.setString("access_token", responseBody['token']['access']);
+      //prefs.setString("refresh_token", responseBody['token']['refresh']);
+
+      //String? accessToken = prefs.getString("access_token");
+      // 유저 데이터 맵을 클래스로 변환
+      // ServiceUser serviceUser = await getServiceUser();
+      // MyInfo myInfo = Get.find();
+      // myInfo.setMyInfo(serviceUser);
+
+      // if(serviceUser.user_name==''){ // 유저네임이 없을 경우 랜덤 생성
+      //   Uri uri = Uri.parse('https://nickname.hwanmoo.kr/?format=json&count=15');
+      //   http.Response response = await http.get(uri); //TODO: 랜덤 이름 생성기. 추후 자체서버 구현 필요
+      //   String username = 'invalid user';
+      //   for (String word in jsonDecode(response.body)['words']) {
+      //     if (word.length < 10) username = word;
+      //   }
+      //   DateTime now = await NTP.now();
+      //   String nowString = now.toIso8601String();
+      //   http.Response patchUser = await http.patch(uri,body:{"user_name":username, "updated_at": nowString});
+      //   if(patchUser.statusCode == 400);
+      // }
+    } else {
+      // 에러 처리
+      debugPrint('Authentication failed: ${authResponse.body}');
+      debugPrint('${authResponse.statusCode}');
+    }
+  } catch (e) {
+    // 네트워크 요청 실패 시 처리
+    debugPrint('Error making authentication request: $e');
+  }
+}

--- a/lib/screen/0_login_and_set_address/0_login_screen.dart
+++ b/lib/screen/0_login_and_set_address/0_login_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:hankkitoktok/screen/0_login_and_set_address/temporary_adress.dart';
 import 'package:kakao_flutter_sdk_user/kakao_flutter_sdk_user.dart';
 
 class LoginPage extends StatelessWidget {
@@ -37,9 +38,9 @@ class LoginPage extends StatelessWidget {
                     //   ),
                     // ),
                     InkWell(
-                  onTap: () {
-                    signInKaKao();
-                  },
+                      onTap: () async {
+                        await signInKaKao(context);
+                      },
                   child: Image.asset(
                     'assets/images/kakao_login.png',
                     fit: BoxFit.cover,
@@ -83,7 +84,7 @@ class LoginPage extends StatelessWidget {
     );
   }
 
-  Future<void> signInKaKao() async {
+  Future<void> signInKaKao(BuildContext context) async {
 // 카카오 로그인 구현 예제
 
 // 카카오톡 실행 가능 여부 확인
@@ -92,7 +93,21 @@ class LoginPage extends StatelessWidget {
       try {
         await UserApi.instance.loginWithKakaoTalk().then((value){
           print('value from kakao $value');
-          //여기에 페이지 이동 넣기
+          print("access token: ${value.accessToken}");
+          print("expires_at: ${value.expiresAt}");
+          print("refresh token: ${value.refreshToken}");
+          print("refresh token expires at: ${value.refreshTokenExpiresAt}");
+          print("scopes: ${value.scopes}");
+          print("-------idToken-------");
+          print("id_token: ${value.idToken}");
+          print("---------------------");
+
+          // Navigator.push(
+          //   context,
+          //   MaterialPageRoute(
+          //       builder: (context) =>
+          //           TemporaryAdress(token: value)),
+          // );
         });
         print('카카오톡으로 로그인 성공');
       } catch (error) {

--- a/lib/screen/0_login_and_set_address/temporary_adress.dart
+++ b/lib/screen/0_login_and_set_address/temporary_adress.dart
@@ -1,0 +1,74 @@
+import 'dart:convert';
+import 'package:hankkitoktok/const/strings.dart';
+import 'package:http/http.dart' as http;
+import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:flutter/material.dart';
+import 'package:hankkitoktok/models/user/user_data.dart';
+import 'package:kakao_flutter_sdk_user/kakao_flutter_sdk_user.dart';
+
+class TemporaryAddress extends StatefulWidget {
+  // OAuthToken token;
+  // TemporaryAdress({required this.token, super.key});
+  //이부분 받아서 받은 데이터 넣어주기
+  const TemporaryAddress({super.key});
+
+  @override
+  State<TemporaryAddress> createState() => _TemporaryAdressState();
+}
+
+class _TemporaryAdressState extends State<TemporaryAddress> {
+  String address= '충청북도 청주시 흥덕구 충대로 1';
+  double latitude = 36.6298968;
+  double longitude = 127.4534557;
+  String accessToken='d4iuHfe73n8ecfLxsnnpiF22nr59j20sAAAAAQorDKgAAAGQ-GPYvKbXH4eeWQ3B';
+  String idToken= 'eyJraWQiOiI5ZjI1MmRhZGQ1ZjIzM2Y5M2QyZmE1MjhkMTJmZWEiLCJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJhdWQiOiJjMWVkYTVlYzc1YmI4NDNhY2VmMjgzYjhiNGEyOTdmMSIsInN1YiI6IjM2NDExMDU2MDEiLCJhdXRoX3RpbWUiOjE3MjIxNTQyMTEsImlzcyI6Imh0dHBzOi8va2F1dGgua2FrYW8uY29tIiwibmlja25hbWUiOiLrsJXsiJzsmIEiLCJleHAiOjE3MjIxOTc0MTEsImlhdCI6MTcyMjE1NDIxMSwicGljdHVyZSI6Imh0dHBzOi8vdDEua2FrYW9jZG4ubmV0L2FjY291bnRfaW1hZ2VzL2RlZmF1bHRfcHJvZmlsZS5qcGVnLnR3Zy50aHVtYi5SMTEweDExMCJ9.HsITUDBbNT6fLrjCJaxdZHdQ3aVJHLb02XO6A4Qn3Vi7gZcBa5RYkDm3uzhufOBaZo99RAQOMWCRJ2t6zdoPRRJ_lWs1sVolRxU_wE6eetLLp18t9lcLkfI-URLwW7FI33aJvNra6C7KcEWLEA0BfkDEq4Uwka0n4GzXMmbX_OR-_2WvHKZw1cwVjVPDRFfsGH205K3f_hSSQnZmULDGPzfi2MJPqlKzm7r8w5yZAdOfwd-DMhg6nZonBzFeVJD0BwUyL4lJdU16NMj6PSqrqhDpi53N31owhh11woFc-1X20TibHSr_hFtOaZ3b_RTfo25PoU28lXaHo_7UYh4fKQ';
+
+  String deviceToken ='sfdfdfdfsff';
+  void getUDID() async {
+    String? fcmToken = await FirebaseMessaging.instance.getToken();
+    debugPrint(fcmToken ?? 'null');
+  }
+
+  bool isUser=true;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: SafeArea(
+        child: Column(
+          children: [
+            Text("주소 페이지 입니다."),
+            ElevatedButton(onPressed: () async{
+              isUser=await getIsUser(idToken);
+              if(isUser==true){
+                debugPrint('유저ㅇㅇ');
+                await login(accessToken, idToken, deviceToken);
+              }
+              else{
+                debugPrint('유저ㄴㄴ');
+                //회원가입 성공(200)하면 로그인 api요청되도록 구현함
+                await signUp(address, latitude, longitude, accessToken, idToken, deviceToken);
+              }
+            }, child: Text('유저인지 확인하기+로그인+회원가입')),
+            ElevatedButton(onPressed: () async{
+              isUser=await getIsUser(idToken);
+              if(isUser==true){
+                debugPrint('유저ㅇㅇ');
+              }
+              else{
+                debugPrint('유저ㄴㄴ');
+              }
+            }, child: Text('유저인지 확인하기')),
+            ElevatedButton(onPressed: () async{
+              await signUp(address, latitude, longitude, accessToken, idToken, deviceToken);
+            }, child: Text('회원가입')),
+
+            ElevatedButton(onPressed: () async{
+              await login(accessToken, idToken, deviceToken);
+            }, child: Text('로그인')),
+          ],
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
<추가한 기능>
카카오 로그인 후 받은 데이터를 서버와 연동하여 회원가입 및 로그인하는 기능을 추가했습니다.

<코드리뷰 받고싶은 점>
예외처리에서 좀 더 세분화할 부분이 있는지 궁금합니다.

<어려웠던 점>
API에서 POST기능과 연동할 때 토큰 정보를 쿼리 파라미터로 넣어야 했는데, 이전 프로젝트에서는 body에 넣어 진행했기에 헷갈리는 부분이 있었습니다. 
기기와 컴퓨터가 연결되지 않아 유효한 토큰으로는 테스트 해볼 수 없었습니다. 기기와 연결되는 컴퓨터로 추후 테스트 해볼 예정입니다. 